### PR TITLE
feat: interactive calendar with day events modal and scraping fixes

### DIFF
--- a/app/api/cron/calendar-update/route.ts
+++ b/app/api/cron/calendar-update/route.ts
@@ -3,11 +3,12 @@ export const dynamic = "force-dynamic";
 import { calendarFileController } from "@server/controller/calendarFile";
 
 export async function GET(request: Request) {
-  // const authHeader = request.headers.get("authorization");
-  // if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-  //   return new Response("Unauthorized", {
-  //     status: 401,
-  //   });
-  // }
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  }
   return await calendarFileController.postUpdateCalendar(request);
 }

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -3,6 +3,8 @@ import { ThemeProvider } from "@contexts/ThemeContext";
 import { GlobalStyle } from "app/styles/global";
 import {
   Content,
+  EventDot,
+  EventLabel,
   LoadingMessage,
   Main,
   MonthItem,
@@ -12,12 +14,13 @@ import {
 } from "./style";
 import Header from "@components/Header";
 import Footer from "@components/Footer";
-import CustomCalendar from "@components/CustomCalendar";
+import CustomCalendar, { SpecialDate } from "@components/CustomCalendar";
 import { semesterController } from "@ui/controller/semester";
 import React from "react";
 import { Event } from "@ui/schema/event";
 import Accordion from "@components/Accordion";
 import Table from "@components/Table";
+import { EventType } from "app/styles/eventTypes";
 
 interface Semester {
   title: string;
@@ -26,15 +29,32 @@ interface Semester {
   event_groups: { [key: string]: Event[] };
 }
 
-interface SpecialDates {
-  id: string;
-  date: Date;
-  type: "HOLIDAY" | "ACADEMIC" | "IMPORTANT";
+function getEventType(event: Event): EventType {
+  if (event.is_important) return "IMPORTANT";
+  if (event.is_holiday) return "HOLIDAY";
+  return "ACADEMIC";
+}
+
+function getDates(startDate: Date, stopDate: Date) {
+  const dateArray = [];
+  const currentDate = new Date(startDate);
+  while (currentDate <= stopDate) {
+    dateArray.push(new Date(currentDate));
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+  return dateArray;
+}
+
+// Formats the date as "dd/MM"
+function formatDate(date: Date) {
+  const day = date.getDate().toString().padStart(2, "0");
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  return `${day}/${month}`;
 }
 
 export default function Calendar() {
   const [semesters, setSemesters] = React.useState<Semester[]>([]);
-  const [specialDates, setSpecialDates] = React.useState<SpecialDates[]>([]);
+  const [specialDates, setSpecialDates] = React.useState<SpecialDate[]>([]);
   const monthList = {
     "0": "Janeiro",
     "1": "Fevereiro",
@@ -53,56 +73,29 @@ export default function Calendar() {
   const tableHeaders = [{ title: "Data" }, { title: "Evento", width: "100%" }];
   const tableAligns = ["center", "left"];
 
-  function getDates(startDate: Date, stopDate: Date) {
-    const dateArray = [];
-    const currentDate = startDate;
-    while (currentDate <= stopDate) {
-      dateArray.push(new Date(currentDate));
-      currentDate.setDate(currentDate.getDate() + 1);
-    }
-    return dateArray;
-  }
-
-  // Function to format date to string, with the format "dd/MM"
-  function formatDate(date: Date) {
-    const day = date.getDate().toString().padStart(2, "0");
-    const month = (date.getMonth() + 1).toString().padStart(2, "0");
-    return `${day}/${month}`;
-  }
-
   React.useEffect(() => {
     semesterController.getEvents().then(({ events }) => {
       setSemesters(events);
 
-      const specialDates = events.reduce<SpecialDates[]>((acc, semester) => {
-        const semesterSpecialDates = Object.entries(
-          semester.event_groups
-        ).reduce<SpecialDates[]>((acc, [, events]) => {
-          return [
-            ...acc,
-            ...events.reduce<SpecialDates[]>((acc, event) => {
-              if (!event.start_at || !event.end_at) {
-                return acc;
-              }
-              const type = event.is_important
-                ? "IMPORTANT"
-                : event.is_holiday
-                ? "HOLIDAY"
-                : "ACADEMIC";
-              const startDate = new Date(event.start_at);
-              const endDate = new Date(event.end_at);
-              const dates = getDates(startDate, endDate);
-              const specialDates = dates.map<SpecialDates>((date) => ({
-                date,
-                type,
-                id: event.title,
-              }));
-              return [...acc, ...specialDates];
-            }, []),
-          ];
-        }, []);
-        return [...acc, ...semesterSpecialDates];
-      }, []);
+      const specialDates = events.flatMap((semester) =>
+        Object.values(semester.event_groups).flatMap((events) =>
+          events.flatMap<SpecialDate>((event) => {
+            if (!event.start_at || !event.end_at) {
+              return [];
+            }
+            const type = getEventType(event);
+            const startAt = new Date(event.start_at);
+            const endAt = new Date(event.end_at);
+            return getDates(startAt, endAt).map((date) => ({
+              date,
+              type,
+              id: event.title,
+              startAt,
+              endAt,
+            }));
+          })
+        )
+      );
       setSpecialDates(specialDates);
     });
   }, []);
@@ -157,7 +150,13 @@ export default function Calendar() {
                                 const endDate = formatDate(event.end_at);
                                 if (endDate !== date) date += ` - ${endDate}`;
                               }
-                              return [date, event.title];
+                              return [
+                                date,
+                                <EventLabel key={event.id}>
+                                  <EventDot type={getEventType(event)} />
+                                  {event.title}
+                                </EventLabel>,
+                              ];
                             })}
                             aligns={tableAligns}
                           />

--- a/app/calendar/style.ts
+++ b/app/calendar/style.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { EventType, eventTypeColors } from "app/styles/eventTypes";
 
 export const Main = styled("main")`
   background-color: ${(props) => props.theme.primary};
@@ -38,7 +39,29 @@ export const MonthItem = styled("li")`
 
 export const MonthTitle = styled("h3")`
   text-align: center;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 1rem;
+  opacity: 0.9;
+`;
+
+export const EventLabel = styled("span")`
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+`;
+
+interface EventDotProps {
+  type: EventType;
+}
+
+export const EventDot = styled("span")<EventDotProps>`
+  flex-shrink: 0;
+  width: 0.4375rem;
+  height: 0.4375rem;
+  border-radius: 50%;
+  background: ${(props) => eventTypeColors[props.type]};
 `;
 
 export const LoadingMessage = styled("p")`

--- a/app/components/Accordion/styles.ts
+++ b/app/components/Accordion/styles.ts
@@ -1,13 +1,18 @@
 import styled from "styled-components";
 
 export const Container = styled("div")`
-  border-top: 0.025rem solid ${(props) => props.theme.secondary};
-  border-bottom: 0.025rem solid ${(props) => props.theme.secondary};
+  border: 1px solid ${(props) => props.theme.secondary}55;
+  border-radius: 0.75rem;
+  overflow: hidden;
   width: 100%;
+
+  & + & {
+    margin-top: 1rem;
+  }
 `;
 
 export const Header = styled("div")`
-  padding: 0.5rem 2rem;
+  padding: 0.75rem 1.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -19,18 +24,24 @@ export const Header = styled("div")`
   }
 
   &:hover {
-    background-color: ${(props) => props.theme.secondary}33;
+    background-color: ${(props) => props.theme.secondary}22;
   }
 `;
 
-export const Title = styled("h2")``;
+export const Title = styled("h2")`
+  font-size: 1.25rem;
+`;
 
 interface ContentProps {
   $isOpen: boolean;
 }
 
 export const Content = styled("div")<ContentProps>`
-  padding: 1rem 3rem;
-  border-top: 0.025rem solid ${(props) => props.theme.secondary};
+  padding: 1rem 1.5rem 1.5rem;
+  border-top: 1px solid ${(props) => props.theme.secondary}55;
   display: ${({ $isOpen }) => ($isOpen ? "block" : "none")};
+
+  @media (max-width: 40rem) {
+    padding: 0.75rem;
+  }
 `;

--- a/app/components/CustomCalendar/index.tsx
+++ b/app/components/CustomCalendar/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   Calendar,
   Container,
@@ -5,23 +6,30 @@ import {
   HighlightList,
   LegendItem,
   LegendList,
+  MoreEventsBadge,
 } from "./style";
 import "react-calendar/dist/Calendar.css";
+import DayEventsModal, { DayEvent } from "@components/DayEventsModal";
+import {
+  EventType,
+  eventTypeLabels,
+  eventTypePriority,
+} from "app/styles/eventTypes";
 
-type TypeDate = "HOLIDAY" | "ACADEMIC" | "IMPORTANT";
-
-type SpecialDates = {
+export type SpecialDate = {
   id: string;
   date: Date;
-  type: TypeDate;
+  type: EventType;
+  startAt: Date;
+  endAt: Date;
 };
 
 interface MarkersSpecialDate {
-  [key: string]: { [K in TypeDate]: string[] };
+  [key: string]: DayEvent[];
 }
 
 interface CustomCalendarProps {
-  specialDates: SpecialDates[];
+  specialDates: SpecialDate[];
   minDate?: Date;
   maxDate?: Date;
 }
@@ -31,38 +39,56 @@ export default function CustomCalendar({
   minDate,
   maxDate,
 }: CustomCalendarProps) {
-  const markers = specialDates.reduce((acc, { date, type, id }) => {
-    const key = date.toDateString();
-    if (!acc[key]) {
-      acc[key] = { HOLIDAY: [], ACADEMIC: [], IMPORTANT: [] };
-    }
-    acc[key][type].push(id);
-    return acc;
-  }, {} as MarkersSpecialDate);
+  const [selectedDate, setSelectedDate] = React.useState<Date | null>(null);
+
+  const markers = React.useMemo(
+    () =>
+      specialDates.reduce((acc, { date, type, id, startAt, endAt }) => {
+        const key = date.toDateString();
+        if (!acc[key]) {
+          acc[key] = [];
+        }
+        acc[key].push({ title: id, type, startAt, endAt });
+        return acc;
+      }, {} as MarkersSpecialDate),
+    [specialDates]
+  );
+
+  function getTypesOfDay(date: Date): EventType[] {
+    const events = markers[date.toDateString()];
+    if (!events) return [];
+    return eventTypePriority.filter((type) =>
+      events.some((event) => event.type === type)
+    );
+  }
 
   function setTileContent({ date, view }: { date: Date; view: string }) {
+    if (view !== "month") return null;
+    const events = markers[date.toDateString()];
+    if (!events) return null;
+    const types = getTypesOfDay(date);
+
     return (
-      view === "month" && (
-        <HighlightList>
-          {markers[date.toDateString()] && (
-            <>
-              {["IMPORTANT", "HOLIDAY", "ACADEMIC"].map((type) => {
-                if (markers[date.toDateString()][type as TypeDate].length > 0)
-                  return (
-                    <HighlightItem
-                      type={type as TypeDate}
-                      key={`${date.toDateString()}-${type}`}
-                    >
-                      {markers[date.toDateString()][type as TypeDate].length}
-                    </HighlightItem>
-                  );
-                return null;
-              })}
-            </>
-          )}
-        </HighlightList>
-      )
+      <HighlightList>
+        {types.map((type) => (
+          <HighlightItem type={type} key={`${date.toDateString()}-${type}`} />
+        ))}
+        {events.length > 3 && <MoreEventsBadge>+</MoreEventsBadge>}
+      </HighlightList>
     );
+  }
+
+  function setTileClassName({ date, view }: { date: Date; view: string }) {
+    if (view === "month" && markers[date.toDateString()]) {
+      return "has-events";
+    }
+    return null;
+  }
+
+  function handleClickDay(date: Date) {
+    if (markers[date.toDateString()]) {
+      setSelectedDate(date);
+    }
   }
 
   return (
@@ -71,19 +97,27 @@ export default function CustomCalendar({
         locale="pt-BR"
         minDetail="year"
         tileContent={setTileContent}
-        onClickDay={() => {
-          return;
-        }}
+        tileClassName={setTileClassName}
+        onClickDay={handleClickDay}
         minDate={minDate}
         maxDate={maxDate}
         prev2Label={null}
         next2Label={null}
       />
       <LegendList>
-        <LegendItem type="HOLIDAY">Feriado ou recesso</LegendItem>
-        <LegendItem type="IMPORTANT">Data importante</LegendItem>
-        <LegendItem type="ACADEMIC">Data acadêmica</LegendItem>
+        {eventTypePriority.map((type) => (
+          <LegendItem key={type} type={type}>
+            {eventTypeLabels[type]}
+          </LegendItem>
+        ))}
       </LegendList>
+      {selectedDate && (
+        <DayEventsModal
+          date={selectedDate}
+          events={markers[selectedDate.toDateString()] ?? []}
+          onClose={() => setSelectedDate(null)}
+        />
+      )}
     </Container>
   );
 }

--- a/app/components/CustomCalendar/style.ts
+++ b/app/components/CustomCalendar/style.ts
@@ -1,36 +1,91 @@
 import styled from "styled-components";
 import ReactCalendar from "react-calendar";
-
-const highlightColors = {
-  HOLIDAY: "deepskyblue",
-  ACADEMIC: "gray",
-  IMPORTANT: "red",
-};
+import { EventType, eventTypeColors } from "app/styles/eventTypes";
 
 export const Container = styled("div")`
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   justify-content: center;
+  width: min(24rem, calc(100vw - 2rem));
 `;
 
 export const Calendar = styled(ReactCalendar)`
-  background-color: ${(props) => props.theme.primary};
-  border: 1px solid ${(props) => props.theme.secondary};
-
-  .react-calendar__month-view__weekdays__weekday abbr[title] {
-    text-decoration: none;
+  &.react-calendar {
+    width: 100%;
+    background-color: ${(props) => props.theme.primary};
+    color: ${(props) => props.theme.secondary};
+    border: 1px solid ${(props) => props.theme.secondary}55;
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    font-family: inherit;
+    line-height: 1.2;
   }
 
-  * button:enabled:hover,
-  * button:disabled {
-    background: ${(props) => props.theme.secondary}33;
+  .react-calendar__navigation {
+    margin-bottom: 0.25rem;
+
+    button {
+      color: ${(props) => props.theme.secondary};
+      font-size: 1rem;
+      font-weight: bold;
+      border-radius: 0.5rem;
+    }
+
+    .react-calendar__navigation__label__labelText {
+      display: inline-block;
+
+      &::first-letter {
+        text-transform: uppercase;
+      }
+    }
+
+    button:enabled:hover,
+    button:enabled:focus {
+      background: ${(props) => props.theme.secondary}22;
+    }
+
+    button:disabled {
+      background: none;
+      opacity: 0.4;
+    }
+  }
+
+  .react-calendar__month-view__weekdays__weekday {
+    font-size: 0.6875rem;
+    opacity: 0.75;
+
+    abbr[title] {
+      text-decoration: none;
+    }
+  }
+
+  .react-calendar__month-view__days__day--neighboringMonth {
+    opacity: 0.35;
   }
 
   .react-calendar__tile {
-    padding: 0.5rem 0.375rem;
+    padding: 0.375rem 0.125rem 0.25rem;
     font-weight: bold;
-    font-size: 1rem;
+    font-size: 0.875rem;
+    color: ${(props) => props.theme.secondary};
+    border-radius: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.125rem;
+    min-height: 2.5rem;
+  }
+
+  .react-calendar__tile:disabled {
+    background: none;
+    color: ${(props) => props.theme.secondary};
+    opacity: 0.35;
+  }
+
+  .react-calendar__tile:enabled:hover,
+  .react-calendar__tile:enabled:focus {
+    background: ${(props) => props.theme.secondary}22;
   }
 
   .react-calendar__tile--active,
@@ -38,57 +93,77 @@ export const Calendar = styled(ReactCalendar)`
     background: none;
   }
 
+  .react-calendar__tile--active:enabled:hover {
+    background: ${(props) => props.theme.secondary}22;
+  }
+
   .react-calendar__tile--now {
-    background: none;
     background: ${(props) => props.theme.secondary};
 
     abbr {
       color: ${(props) => props.theme.primary};
-      font-weight: bold;
     }
+
+    &:enabled:hover,
+    &:enabled:focus {
+      background: ${(props) => props.theme.secondary}CC;
+    }
+  }
+
+  .react-calendar__tile.has-events {
+    cursor: pointer;
+  }
+
+  .react-calendar__year-view__months__month {
+    text-transform: capitalize;
+    min-height: 3rem;
+    justify-content: center;
   }
 `;
 
 export const HighlightList = styled("ul")`
   list-style: none;
   display: flex;
-  gap: 0.125rem;
+  gap: 0.1875rem;
   justify-content: center;
   align-items: center;
+  min-height: 0.4375rem;
 `;
 
 interface HighlightItemProps {
-  type: keyof typeof highlightColors;
+  type: EventType;
 }
 
 export const HighlightItem = styled("li")<HighlightItemProps>`
-  width: 0.625rem;
-  height: 0.625rem;
-  background: ${(props) => highlightColors[props.type]};
+  width: 0.4375rem;
+  height: 0.4375rem;
+  background: ${(props) => eventTypeColors[props.type]};
   border-radius: 50%;
+`;
 
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  font-size: 0.55rem;
-  color: white;
+export const MoreEventsBadge = styled("li")`
+  font-size: 0.5625rem;
+  font-weight: bold;
+  line-height: 0.4375rem;
+  opacity: 0.75;
 `;
 
 export const LegendList = styled("ul")`
   list-style: none;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
   padding: 0;
 `;
 
 interface LegendItemProps {
-  type: keyof typeof highlightColors;
+  type: EventType;
 }
 
 export const LegendItem = styled("li")<LegendItemProps>`
   display: flex;
-  gap: 0.25rem;
+  gap: 0.375rem;
   align-items: center;
 
   font-size: 0.75rem;
@@ -96,9 +171,9 @@ export const LegendItem = styled("li")<LegendItemProps>`
   &::before {
     content: "";
     display: block;
-    width: 0.35rem;
-    height: 0.35rem;
-    background: ${(props) => highlightColors[props.type]};
+    width: 0.4375rem;
+    height: 0.4375rem;
+    background: ${(props) => eventTypeColors[props.type]};
     border-radius: 50%;
   }
 `;

--- a/app/components/DayEventsModal/index.tsx
+++ b/app/components/DayEventsModal/index.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import Overlay from "@components/Overlay";
+import CloseIcon from "@assets/icons/close.svg";
+import { EventType, eventTypePriority } from "app/styles/eventTypes";
+import {
+  CloseButton,
+  Container,
+  EmptyMessage,
+  EventItem,
+  EventList,
+  EventPeriod,
+  EventTitle,
+  EventTypeDot,
+  Header,
+  Title,
+} from "./style";
+
+export interface DayEvent {
+  title: string;
+  type: EventType;
+  startAt: Date;
+  endAt: Date;
+}
+
+interface DayEventsModalProps {
+  date: Date;
+  events: DayEvent[];
+  onClose: () => void;
+}
+
+function formatShortDate(date: Date) {
+  return date.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" });
+}
+
+function formatPeriod(event: DayEvent) {
+  const start = formatShortDate(event.startAt);
+  const end = formatShortDate(event.endAt);
+  return start === end ? start : `${start} até ${end}`;
+}
+
+export default function DayEventsModal({
+  date,
+  events,
+  onClose,
+}: DayEventsModalProps) {
+  React.useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const sortedEvents = [...events].sort(
+    (a, b) =>
+      eventTypePriority.indexOf(a.type) - eventTypePriority.indexOf(b.type)
+  );
+
+  const formattedDate = date.toLocaleDateString("pt-BR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <>
+      <Overlay onClick={onClose} />
+      <Container role="dialog" aria-modal="true" aria-label={formattedDate}>
+        <Header>
+          <Title>{formattedDate}</Title>
+          <CloseButton onClick={onClose} aria-label="Fechar">
+            <CloseIcon />
+          </CloseButton>
+        </Header>
+        {sortedEvents.length > 0 ? (
+          <EventList>
+            {sortedEvents.map((event, index) => (
+              <EventItem key={`${event.title}-${index}`}>
+                <EventTypeDot type={event.type} />
+                <div>
+                  <EventTitle>{event.title}</EventTitle>
+                  <EventPeriod>{formatPeriod(event)}</EventPeriod>
+                </div>
+              </EventItem>
+            ))}
+          </EventList>
+        ) : (
+          <EmptyMessage>Nenhum evento neste dia.</EmptyMessage>
+        )}
+      </Container>
+    </>
+  );
+}

--- a/app/components/DayEventsModal/style.ts
+++ b/app/components/DayEventsModal/style.ts
@@ -1,0 +1,102 @@
+import styled from "styled-components";
+import { EventType, eventTypeColors } from "app/styles/eventTypes";
+
+export const Container = styled("div")`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+
+  width: min(28rem, calc(100vw - 2rem));
+  max-height: 70vh;
+  overflow-y: auto;
+
+  background: ${(props) => props.theme.primary};
+  color: ${(props) => props.theme.secondary};
+  border: 1px solid ${(props) => props.theme.secondary}55;
+  border-radius: 0.75rem;
+  box-shadow: 0 1rem 3rem #00000059;
+  padding: 1.25rem;
+`;
+
+export const Header = styled("div")`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+`;
+
+export const Title = styled("h2")`
+  font-size: 1.125rem;
+
+  &::first-letter {
+    text-transform: uppercase;
+  }
+`;
+
+export const CloseButton = styled("button")`
+  display: flex;
+  padding: 0.25rem;
+  border-radius: 50%;
+  transition: background-color 0.2s ease-in-out;
+
+  svg {
+    fill: ${(props) => props.theme.secondary};
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  &:hover {
+    background-color: ${(props) => props.theme.secondary}33;
+  }
+`;
+
+export const EventList = styled("ul")`
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const EventItem = styled("li")`
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+
+  padding: 0.625rem 0.75rem;
+  border: 1px solid ${(props) => props.theme.secondary}22;
+  border-radius: 0.5rem;
+  background: ${(props) => props.theme.secondary}0D;
+`;
+
+interface EventTypeDotProps {
+  type: EventType;
+}
+
+export const EventTypeDot = styled("span")<EventTypeDotProps>`
+  flex-shrink: 0;
+  width: 0.625rem;
+  height: 0.625rem;
+  margin-top: 0.375rem;
+  border-radius: 50%;
+  background: ${(props) => eventTypeColors[props.type]};
+`;
+
+export const EventTitle = styled("p")`
+  font-weight: 500;
+  line-height: 1.4;
+`;
+
+export const EventPeriod = styled("p")`
+  font-size: 0.8125rem;
+  opacity: 0.75;
+  margin-top: 0.125rem;
+`;
+
+export const EmptyMessage = styled("p")`
+  text-align: center;
+  opacity: 0.75;
+  padding: 1rem 0;
+`;

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   Container,
   TableBody,
@@ -14,7 +15,7 @@ type Header = {
 
 interface TableProps {
   headers: Header[];
-  rows: string[][];
+  rows: React.ReactNode[][];
   aligns?: string[];
 }
 

--- a/app/components/Table/styles.ts
+++ b/app/components/Table/styles.ts
@@ -19,13 +19,21 @@ interface TableHeaderCellProps {
 }
 
 export const TableHeaderCell = styled("th")<TableHeaderCellProps>`
-  padding-bottom: 0.5rem;
+  padding: 0.375rem 0.5rem;
   min-width: ${(props) => props.width ?? "7.5rem"};
-  border-bottom: 0.025rem solid ${(props) => props.theme.secondary};
+  border-bottom: 1px solid ${(props) => props.theme.secondary}88;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  opacity: 0.85;
 `;
 
 export const TableBody = styled("tbody")`
   width: 100%;
+
+  ${TableRow}:nth-child(even) {
+    background: ${(props) => props.theme.secondary}0D;
+  }
 `;
 
 interface TableBodyCellProps {
@@ -37,7 +45,13 @@ export const TableBodyCell = styled("td")<TableBodyCellProps>`
   width: ${(props) => props.width ?? "auto"};
   padding: 0.5rem;
   text-align: ${(props) => props.$align ?? "auto"};
-  border-bottom: 0.025rem solid ${(props) => props.theme.secondary};
+  border-bottom: 1px solid ${(props) => props.theme.secondary}33;
+  line-height: 1.4;
+
+  &:first-child {
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
 
   li {
     margin-top: 0.5rem;

--- a/app/styles/eventTypes.ts
+++ b/app/styles/eventTypes.ts
@@ -1,0 +1,20 @@
+export type EventType = "HOLIDAY" | "ACADEMIC" | "IMPORTANT";
+
+// Colors readable on both the light (#FDFDFD) and dark (#284480) themes
+export const eventTypeColors: Record<EventType, string> = {
+  IMPORTANT: "#E5484D",
+  HOLIDAY: "#12A594",
+  ACADEMIC: "#9BA1A6",
+};
+
+export const eventTypeLabels: Record<EventType, string> = {
+  IMPORTANT: "Data importante",
+  HOLIDAY: "Feriado ou recesso",
+  ACADEMIC: "Data acadêmica",
+};
+
+export const eventTypePriority: EventType[] = [
+  "IMPORTANT",
+  "HOLIDAY",
+  "ACADEMIC",
+];

--- a/src/server/controller/calendarFile.ts
+++ b/src/server/controller/calendarFile.ts
@@ -1,9 +1,16 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { calendarFileRepository } from "@server/repository/calendarFile";
 import { semesterRepository } from "@server/repository/semester";
 import { CalendarFile } from "@server/schema/calendarFile";
 import { difference } from "@server/utils/setOperations";
 
+interface ProcessResult {
+  title: string;
+  status: "updated" | "skipped" | "error";
+  semester?: string;
+  events?: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function postUpdateCalendar(_req: Request) {
   const calendarsSaved = await calendarFileRepository.list();
   const calendarsSite = await calendarFileRepository.listFilesInSite();
@@ -18,37 +25,72 @@ async function postUpdateCalendar(_req: Request) {
     "title"
   );
 
-  calendarsUnsaved.forEach(async (calendarFile) => {
-    const calendarData = await calendarFileRepository.getCalendarDataByURL(
-      calendarFile.link
-    );
+  const results: ProcessResult[] = [];
 
-    await semesterRepository.deleteEventsInSemester(calendarData.semester);
-    await semesterRepository.deleteSemester(calendarData.semester);
-    const start_at = calendarData.infos.find((info) =>
-      info.title.includes("Início do semestre")
-    )?.start_at;
-    const end_at = calendarData.infos.find((info) =>
-      info.title.includes("Encerramento das aulas")
-    )?.end_at;
-    await semesterRepository.createSemester({
-      title: calendarData.semester,
-      start_at: start_at ?? "",
-      end_at: end_at ?? "",
-    });
-    calendarData.infos.forEach(async (info) => {
-      await semesterRepository.createEventInSemester(calendarData.semester, {
-        start_at: info.start_at ? info.start_at : null,
-        end_at: info.start_at ? info.end_at : null,
-        title: info.title,
-        is_holiday: info.is_holiday,
-        is_important: info.is_important,
+  for (const calendarFile of calendarsUnsaved) {
+    try {
+      const calendarData = await calendarFileRepository.getCalendarDataByURL(
+        calendarFile.link
+      );
+
+      const start_at = calendarData.infos.find((info) =>
+        info.title.includes("Início do semestre")
+      )?.start_at;
+      const end_at = calendarData.infos.find((info) =>
+        info.title.includes("Encerramento das aulas")
+      )?.end_at;
+
+      // Partial amendment resolutions (e.g. "Calendário 2025.2 - Alterado")
+      // don't carry the full calendar; replacing the semester with them
+      // would wipe the events already saved.
+      if (!calendarData.semester || !start_at || !end_at) {
+        console.warn(
+          `[calendar-update] "${calendarFile.title}" ignorado: calendário incompleto (${calendarData.infos.length} eventos)`
+        );
+        await calendarFileRepository.saveFile(calendarFile);
+        results.push({ title: calendarFile.title, status: "skipped" });
+        continue;
+      }
+
+      await semesterRepository.deleteEventsInSemester(calendarData.semester);
+      await semesterRepository.deleteSemester(calendarData.semester);
+      await semesterRepository.createSemester({
+        title: calendarData.semester,
+        start_at,
+        end_at,
       });
-    });
-    await calendarFileRepository.saveFile(calendarFile);
-  });
+      await Promise.all(
+        calendarData.infos.map((info) =>
+          semesterRepository.createEventInSemester(calendarData.semester, {
+            start_at: info.start_at ? info.start_at : null,
+            end_at: info.start_at ? info.end_at : null,
+            title: info.title,
+            is_holiday: info.is_holiday,
+            is_important: info.is_important,
+          })
+        )
+      );
+      await calendarFileRepository.saveFile(calendarFile);
 
-  return new Response(undefined, { status: 204 });
+      console.warn(
+        `[calendar-update] "${calendarFile.title}" atualizado: semestre ${calendarData.semester} com ${calendarData.infos.length} eventos`
+      );
+      results.push({
+        title: calendarFile.title,
+        status: "updated",
+        semester: calendarData.semester,
+        events: calendarData.infos.length,
+      });
+    } catch (error) {
+      console.error(
+        `[calendar-update] Falha ao processar "${calendarFile.title}"`,
+        error
+      );
+      results.push({ title: calendarFile.title, status: "error" });
+    }
+  }
+
+  return Response.json({ processed: results });
 }
 
 export const calendarFileController = {

--- a/src/server/repository/calendarFile.ts
+++ b/src/server/repository/calendarFile.ts
@@ -22,10 +22,19 @@ async function list(): Promise<CalendarFile[]> {
   return parsedCalendarFiles;
 }
 
+// Some servers block the default axios User-Agent in cloud environments
+const httpConfig = {
+  timeout: 30000,
+  headers: {
+    "User-Agent":
+      "Mozilla/5.0 (compatible; SemestreUEFS/1.0; +https://semestreuefs.laerciorios.com)",
+  },
+};
+
 async function listFilesInSite(): Promise<CalendarFile[]> {
   const URL =
     "http://www.prograd.uefs.br/modules/conteudo/conteudo.php?conteudo=6";
-  const response = await axios.get(URL);
+  const response = await axios.get(URL, httpConfig);
   const content = response.data;
 
   const $ = cheerio.load(content);
@@ -64,6 +73,7 @@ async function getCalendarDataByURL(url: string) {
       urlTransformed = `https://drive.usercontent.google.com/download?id=${idDrive}`;
   }
   const response = await axios.get(urlTransformed, {
+    ...httpConfig,
     responseType: "arraybuffer",
   });
   const contentBuffer = Buffer.from(response.data, "binary");

--- a/src/server/repository/semester.ts
+++ b/src/server/repository/semester.ts
@@ -212,10 +212,15 @@ async function deleteEventsInSemester(title: string): Promise<void> {
     const semester = await getSemesterByTitle(title);
     const events = semester.events || [];
 
-    events.forEach(async (event) => {
-      if (event.id)
-        await deleteDoc(doc(firebase(), `semesters/${title}/events`, event.id));
-    });
+    await Promise.all(
+      events
+        .filter((event) => event.id)
+        .map((event) =>
+          deleteDoc(
+            doc(firebase(), `semesters/${title}/events`, event.id as string)
+          )
+        )
+    );
   } catch (error) {
     return;
   }

--- a/src/server/utils/stateMachineCalendarInfo.ts
+++ b/src/server/utils/stateMachineCalendarInfo.ts
@@ -13,15 +13,14 @@ interface MachineStateReturn {
 
 enum State {
   INITIAL,
-  MONTH,
-  INFO,
+  COLLECT,
   END,
 }
 
-const months = {
+const months: { [key: string]: string } = {
   JANEIRO: "01",
   FEVEREIRO: "02",
-  MARÇO: "03",
+  MARCO: "03",
   ABRIL: "04",
   MAIO: "05",
   JUNHO: "06",
@@ -43,14 +42,95 @@ const importantDates = [
   "Encerramento das aulas",
   "Período para realização das provas finais",
 ];
-const importantDatesRegex = new RegExp(importantDates.join("|"));
+const importantDatesRegex = new RegExp(importantDates.join("|"), "i");
 
-function transformDate(date: string, month: string, year: string): string {
-  if (date.match(/^\d{2}\/\d{2}$/)) {
-    const [day, month] = date.split("/");
-    return `${year}-${month}-${day}`;
+// SEI header/footer lines that show up in the middle of the extracted text
+const ignoreRegexes = [
+  /^\s*$/,
+  /Dias letivos\s*:/i,
+  /^Resolução \d+\s+SEI .*pg\. \d+$/i,
+  /^Documento assinado eletronicamente/i,
+  /^conforme horário oficial/i,
+  /^\d{2} de [a-zà-ÿ]+ de \d{4}\.?$/i,
+  /^A autenticidade deste documento/i,
+  /^https?:\/\//i,
+  /^acao=documento_conferir/i,
+  /informando o código verificador/i,
+  /código CRC/i,
+  /^Referência: Processo/i,
+];
+
+function normalizeMonthName(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toUpperCase();
+}
+
+function matchMonthHeader(
+  line: string
+): { month: string; year?: string } | null {
+  const match = line.match(/^\*\s*([A-Za-zÀ-ÿ]+)\s*(?:\/\s*(\d{4}))?\s*$/);
+  if (!match) return null;
+  const month = normalizeMonthName(match[1]);
+  if (!months[month]) return null;
+  return { month, year: match[2] };
+}
+
+function isEventStart(line: string): boolean {
+  if (/^A definir\b/i.test(line)) return true;
+  if (/^até\s+\d{1,2}(\/\d{1,2})?\b/i.test(line)) return true;
+  const day = line.match(/^(\d{2})(?:\/\d{1,2})?(?=[\s,]|$)/);
+  return day !== null && Number(day[1]) <= 31;
+}
+
+function buildDate(
+  day: string,
+  month: string,
+  year: string
+): { date: string; monthNumber: number } {
+  return {
+    date: `${year}-${month}-${day.padStart(2, "0")}`,
+    monthNumber: Number(month),
+  };
+}
+
+// Parses "DD" or "DD/MM" using the current month/year as reference
+function parseDayToken(
+  token: string,
+  currentMonth: string,
+  currentYear: string
+): { date: string; monthNumber: number } {
+  const [day, month] = token.split("/");
+  const monthNumber = month ?? months[currentMonth];
+  return buildDate(day, monthNumber.padStart(2, "0"), currentYear);
+}
+
+const dayToken = String.raw`\d{1,2}(?:\/\d{1,2})?`;
+// "05 a 10", "09 e 10", "25/02 a 03/03", "06, 07, 08 [de outubro [de] 2025]"
+const dateListRegex = new RegExp(
+  String.raw`^(?<first>${dayToken})(?:\s*(?:a|e|,|até)\s+(?:${dayToken}\s*(?:,|e)\s+)*(?<last>${dayToken}))?` +
+    String.raw`(?:\s+de\s+(?<monthName>[A-Za-zÀ-ÿ]+))?(?:\s+de\s+|\s*)?(?<year>\d{4})?`,
+  "i"
+);
+
+function cleanTitle(rawTitle: string): {
+  title: string;
+  is_holiday: boolean;
+  is_important: boolean;
+} {
+  let title = rawTitle
+    .replace(/\s+/g, " ")
+    .replace(/^[\s\-–—,.]+/, "")
+    .trim();
+
+  const is_holiday = /feriado|recesso/i.test(title);
+  if (is_holiday) {
+    title = title.replace(/^(feriado|recesso)\s*[-–—:]?\s*/i, "").trim();
   }
-  return `${year}-${months[month as keyof typeof months]}-${date}`;
+  const is_important = importantDatesRegex.test(title);
+
+  return { title, is_holiday, is_important };
 }
 
 function handleInfo(
@@ -60,83 +140,116 @@ function handleInfo(
 ): CalendarInfo | void {
   let start_at = "";
   let end_at = "";
-  let date = "";
-  if (!info.match(/^A definir/)) {
-    const infos = info.split(" ");
-    if (!infos[0].match(/^\d{2}($|\/)/) || infos.length < 3) {
-      return;
+  let rest = info;
+
+  if (/^A definir\b/i.test(info)) {
+    rest = info.replace(/^A definir\b/i, "");
+  } else if (/^até\s+/i.test(info)) {
+    const match = info.match(new RegExp(String.raw`^até\s+(${dayToken})`, "i"));
+    if (!match) return;
+    const parsed = parseDayToken(match[1], month, year);
+    start_at = parsed.date;
+    end_at = parsed.date;
+    rest = info.slice(match[0].length);
+  } else {
+    const match = info.match(dateListRegex);
+    if (!match || !match.groups) return;
+    const { first, last, monthName, year: explicitYear } = match.groups;
+
+    let referenceMonth = month;
+    if (monthName && months[normalizeMonthName(monthName)]) {
+      referenceMonth = normalizeMonthName(monthName);
     }
-    date = infos[0];
-    start_at = transformDate(infos[0], month, year);
-    if (infos[2].match(/^\d{2}(\/[0-1]\d)?$/)) {
-      end_at = transformDate(infos[2], month, year);
-      date += ` ${infos[1]} ${infos[2]}`;
+    const referenceYear = explicitYear ?? year;
+
+    const start = parseDayToken(first, referenceMonth, referenceYear);
+    start_at = start.date;
+    if (last) {
+      const end = parseDayToken(last, referenceMonth, referenceYear);
+      // Ranges like "15/12 a 20/01" roll the end date over to the next year
+      if (end.monthNumber < start.monthNumber) {
+        end_at = buildDate(
+          last.split("/")[0],
+          String(end.monthNumber).padStart(2, "0"),
+          String(Number(referenceYear) + 1)
+        ).date;
+      } else {
+        end_at = end.date;
+      }
     } else {
       end_at = start_at;
     }
-  } else {
-    date = "A definir";
+    rest = info.slice(match[0].length);
   }
 
-  const is_holiday = /Feriado|Recesso/.test(info);
-  const is_important = importantDatesRegex.test(info);
-  let title = info.replace(date, "").trim();
-  if (is_holiday) {
-    title = title.replace(/Feriado - |Recesso - /, "").trim();
-  }
+  const { title, is_holiday, is_important } = cleanTitle(rest);
+  if (!title) return;
+
   return { start_at, end_at, title, is_holiday, is_important };
 }
 
 export function machineState(pdfContent: string): MachineStateReturn {
   const calendarInfos: CalendarInfo[] = [];
-  const monthRegex = /\*[A-Z]+\/\d{4}/;
-  const ignoreRegex = /Dias letivos:|^\s+$/;
-  const endRegex = /TOTAL:/;
+  const endRegex = /TOTAL\s*:\s*\d+/;
   let currentState = State.INITIAL;
   let currentMonth = "";
   let currentYear = "";
   let currentInfo = "";
   let semester = "";
 
+  function flushInfo() {
+    if (!currentInfo) return;
+    const event = handleInfo(currentInfo, currentMonth, currentYear);
+    if (event) calendarInfos.push(event);
+    currentInfo = "";
+  }
+
   const lines = pdfContent.split("\n");
-  for (const line of lines) {
-    if (line.match(ignoreRegex)) {
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (ignoreRegexes.some((regex) => regex.test(line))) {
       continue;
     }
-    switch (currentState) {
-      case State.INITIAL:
-        if (line.match(/\d{4}\.\d/)) {
-          semester = line.match(/\d{4}\.\d/)?.toString() || "";
-        } else if (line.match(monthRegex)) {
-          [currentMonth, currentYear] = line.replace("*", "").trim().split("/");
-          currentState = State.MONTH;
+
+    if (currentState === State.INITIAL) {
+      const semesterMatch = line.match(/\d{4}\.\d/);
+      const monthHeader = matchMonthHeader(line);
+      if (monthHeader) {
+        currentMonth = monthHeader.month;
+        // "*OUTUBRO" without a year: fall back to the semester year (e.g. "2025.2")
+        currentYear = monthHeader.year ?? semester.split(".")[0] ?? "";
+        currentState = State.COLLECT;
+      } else if (semesterMatch) {
+        semester = semesterMatch[0];
+      }
+      continue;
+    }
+
+    if (currentState === State.COLLECT) {
+      const monthHeader = matchMonthHeader(line);
+      if (monthHeader) {
+        flushInfo();
+        const previousMonthNumber = Number(months[currentMonth]);
+        currentMonth = monthHeader.month;
+        if (monthHeader.year) {
+          currentYear = monthHeader.year;
+        } else if (Number(months[currentMonth]) < previousMonthNumber) {
+          // Year rollover without an explicit year in the header (DEZEMBRO -> JANEIRO)
+          currentYear = String(Number(currentYear) + 1);
         }
+      } else if (line.match(endRegex)) {
+        flushInfo();
+        currentState = State.END;
         break;
-      case State.MONTH:
-        currentState = State.INFO;
+      } else if (isEventStart(line)) {
+        flushInfo();
         currentInfo = line;
-        break;
-      case State.INFO:
-        if (line.match(/^\d|A definir/)) {
-          const event = handleInfo(currentInfo, currentMonth, currentYear);
-          if (event) calendarInfos.push(event);
-          currentInfo = line;
-        } else if (line.match(monthRegex)) {
-          const event = handleInfo(currentInfo, currentMonth, currentYear);
-          if (event) calendarInfos.push(event);
-          currentMonth = line.split("/")[0].replace("*", "").trim();
-          currentState = State.MONTH;
-        } else if (line.match(endRegex)) {
-          const event = handleInfo(currentInfo, currentMonth, currentYear);
-          if (event) calendarInfos.push(event);
-          currentState = State.END;
-        } else {
-          currentInfo += " " + line;
-          currentState = State.INFO;
-        }
-        break;
+      } else if (currentInfo) {
+        currentInfo += " " + line;
+      }
     }
   }
+  flushInfo();
 
   return { semester, infos: calendarInfos };
 }


### PR DESCRIPTION
- fix calendar scraping on Vercel by awaiting all async work in cron route
- skip partial amendment PDFs that would wipe saved semesters
- rewrite PDF parser: month names with accents, SEI footers, "até DD/MM", uppercase FERIADO, year rollover and cross-month ranges
- open a modal with the day's events when clicking a calendar day
- improve calendar, accordion and table visuals with shared event colors